### PR TITLE
[docs] Add implementation links

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -1,0 +1,24 @@
+# Implementations
+
+## Resource Metrics API
+
+- [Heapster](https://github.com/kubernetes/heapster): a application which
+  gathers metrics, writes them to metrics storage "sinks", and exposes the
+  resource metrics API from in-memory storage.
+
+- [Metrics Server](https://github.com/kubernetes/heapster):
+  a lighter-weight in-memory server specifically for the resource metrics
+  API.
+
+## Custom Metrics API
+
+***NB: None of the below implemenations are officially part of Kubernetes.
+They are listed here for convinience.***
+
+- [Prometheus
+  Adapter](https://github.com/directxman12/k8s-prometheus-adapter).  An
+  implementation of the custom metrics API that attempts to support
+  arbitrary metrics following a set label and naming scheme.
+
+- [Google Stackdriver (coming
+  soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)

--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@ library when implementing their API servers.
 
 ## APIs
 
-This repository contains (or will contain) types and clients for the
-following APIs:
+This repository contains types and clients for the following APIs:
 
 ### Custom Metrics API
-
-**[Coming Soon]**
 
 This API allows consumers to access arbitrary metrics which describe
 Kubernetes resources.
@@ -28,6 +25,17 @@ The API is intended to be implemented by monitoring pipeline vendors, on
 top of their metrics storage solutions.
 
 Import Path: `k8s.io/metrics/pkg/apis/custom_metrics`.
+
+### Resource Metrics API
+
+This API allows consumers to access resource metrics (CPU and memory) for
+pods and nodes.
+
+The API is implemented by Heapster
+(https://github.com/kubernetes/heapster) and metrics-server
+(https://github.com/kubernetes-incubator/metrics-server).
+
+Import Path: `k8s.io/metrics/pkg/apis/metrics`.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ library when implementing their API servers.
 
 ## APIs
 
-This repository contains types and clients for the following APIs:
+This repository contains types and clients for several APIs.  For more
+details on implemenations of these apis, see
+[IMPLEMENTATIONS.md](IMPLEMENTATIONS.md).
 
 ### Custom Metrics API
 
@@ -23,6 +25,11 @@ Kubernetes resources.
 
 The API is intended to be implemented by monitoring pipeline vendors, on
 top of their metrics storage solutions.
+
+If you want to implement this an API server for this API, please see the
+[kubernetes-incubator/custom-metrics-apiserver](https://github.com/kubernetes-incubator/custom-metrics-apiserver)
+library, which contains the basic infrastructure required to set up such
+an API server.
 
 Import Path: `k8s.io/metrics/pkg/apis/custom_metrics`.
 


### PR DESCRIPTION
This PR cleans up the README a bit and adds links to known implementations of the APIs in this repository, as well as a link to the custom-metrics-apiserver boilerplate.