### PR TITLE
Restore README and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing guidelines
+
+## How to become a contributor and submit your own code
+
+### Contributor License Agreements
+
+We'd love to accept your patches! Before we can take them, we have to jump a couple of legal hurdles.
+
+Please fill out either the individual or corporate Contributor License Agreement (CLA).
+
+  * If you are an individual writing original source code and you're sure you own the intellectual property, then you'll need to sign an [individual CLA](https://identity.linuxfoundation.org/node/285/node/285/individual-signup).
+  * If you work for a company that wants to allow you to contribute your work, then you'll need to sign a [corporate CLA](https://identity.linuxfoundation.org/node/285/organization-signup).
+
+Follow either of the two links above to access the appropriate CLA and instructions for how to sign and return it. Once we receive it, we'll be able to accept your pull requests.
+
+### Contributing A Patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The [repo owners](OWNERS) will respond to your issue promptly.
+1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
+1. Fork the desired repo, develop and test your code changes.
+1. Submit a pull request.
+
+### Adding dependencies
+
+If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management).

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -1,0 +1,24 @@
+# Implementations
+
+## Resource Metrics API
+
+- [Heapster](https://github.com/kubernetes/heapster): a application which
+  gathers metrics, writes them to metrics storage "sinks", and exposes the
+  resource metrics API from in-memory storage.
+
+- [Metrics Server](https://github.com/kubernetes/heapster):
+  a lighter-weight in-memory server specifically for the resource metrics
+  API.
+
+## Custom Metrics API
+
+***NB: None of the below implemenations are officially part of Kubernetes.
+They are listed here for convinience.***
+
+- [Prometheus
+  Adapter](https://github.com/directxman12/k8s-prometheus-adapter).  An
+  implementation of the custom metrics API that attempts to support
+  arbitrary metrics following a set label and naming scheme.
+
+- [Google Stackdriver (coming
+  soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# metrics
+
+Kubernetes metrics API type definitions and clients.
+
+## Purpose
+
+This repository contains type definitions and client code for the metrics
+APIs that Kubernetes makes use of.  Depending on the API, the actual
+implementations live elsewhere.
+
+Consumers of the metrics APIs can make use of this repository to access
+implementations of the APIs, while implementors should make use of this
+library when implementing their API servers.
+
+## APIs
+
+This repository contains types and clients for several APIs.  For more
+details on implemenations of these apis, see
+[IMPLEMENTATIONS.md](IMPLEMENTATIONS.md).
+
+### Custom Metrics API
+
+This API allows consumers to access arbitrary metrics which describe
+Kubernetes resources.
+
+The API is intended to be implemented by monitoring pipeline vendors, on
+top of their metrics storage solutions.
+
+If you want to implement this an API server for this API, please see the
+[kubernetes-incubator/custom-metrics-apiserver](https://github.com/kubernetes-incubator/custom-metrics-apiserver)
+library, which contains the basic infrastructure required to set up such
+an API server.
+
+Import Path: `k8s.io/metrics/pkg/apis/custom_metrics`.
+
+### Resource Metrics API
+
+This API allows consumers to access resource metrics (CPU and memory) for
+pods and nodes.
+
+The API is implemented by Heapster
+(https://github.com/kubernetes/heapster) and metrics-server
+(https://github.com/kubernetes-incubator/metrics-server).
+
+Import Path: `k8s.io/metrics/pkg/apis/metrics`.
+
+## Compatibility
+
+The APIs in this repository follow the standard guarantees for Kubernetes
+APIs, and will follow Kubernetes releases.
+
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community
+page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this repository at:
+
+- Slack: #sig-instrumention (on https://kubernetes.slack.com -- get an
+  invite at slack.kubernetes.io)
+- Mailing List:
+  https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation
+
+### Code of Conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes
+Code of Conduct](code-of-conduct.md).
+
+### Contibution Guidelines
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,58 @@
+## Kubernetes Community Code of Conduct
+
+### Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses,
+ without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
+commit themselves to fairly and consistently applying these principles to every aspect
+of managing this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a Kubernetes maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 1.2.0, available at
+http://contributor-covenant.org/version/1/2/0/
+
+### Kubernetes Events Code of Conduct
+
+Kubernetes events are working conferences intended for professional networking and collaboration in the
+Kubernetes community. Attendees are expected to behave according to professional standards and in accordance
+with their employer's policies on appropriate workplace behavior.
+
+While at Kubernetes events or related social networking opportunities, attendees should not engage in
+discriminatory or offensive speech or actions regarding gender, sexuality, race, or religion. Speakers should
+be especially aware of these concerns.
+
+The Kubernetes team does not condone any statements by speakers contrary to these standards.  The Kubernetes
+team reserves the right to deny entrance and/or eject from an event (without refund) any individual found to
+be engaging in discriminatory or offensive speech or actions.
+
+Please bring any concerns to the immediate attention of Kubernetes event staff.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/code-of-conduct.md?pixel)]()


### PR DESCRIPTION
The README and other associated docs got removed during the initial
resync, when the old branch was renamed to "legacy".  This restores
them from that branch.