### PR TITLE
Fix fake clientsets in metrics.k8s.io.

### DIFF
--- a/pkg/apis/metrics/v1alpha1/doc.go
+++ b/pkg/apis/metrics/v1alpha1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
+// +groupName=metrics.k8s.io
 
 package v1alpha1

--- a/pkg/apis/metrics/v1beta1/doc.go
+++ b/pkg/apis/metrics/v1beta1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
+// +groupName=metrics.k8s.io
 
 package v1beta1

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
@@ -32,9 +32,9 @@ type FakeNodeMetricses struct {
 	Fake *FakeMetricsV1alpha1
 }
 
-var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1alpha1", Resource: "nodes"}
+var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1alpha1", Resource: "nodes"}
 
-var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "NodeMetrics"}
+var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1alpha1", Kind: "NodeMetrics"}
 
 // Get takes name of the nodeMetrics, and returns the corresponding nodeMetrics object, and an error if there is any.
 func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.NodeMetrics, err error) {

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
@@ -33,9 +33,9 @@ type FakePodMetricses struct {
 	ns   string
 }
 
-var podmetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1alpha1", Resource: "pods"}
+var podmetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1alpha1", Resource: "pods"}
 
-var podmetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "PodMetrics"}
+var podmetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1alpha1", Kind: "PodMetrics"}
 
 // Get takes name of the podMetrics, and returns the corresponding podMetrics object, and an error if there is any.
 func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.PodMetrics, err error) {

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -31,7 +31,7 @@ type MetricsV1alpha1Interface interface {
 	PodMetricsesGetter
 }
 
-// MetricsV1alpha1Client is used to interact with features provided by the metrics group.
+// MetricsV1alpha1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
@@ -32,9 +32,9 @@ type FakeNodeMetricses struct {
 	Fake *FakeMetricsV1beta1
 }
 
-var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1beta1", Resource: "nodes"}
+var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}
 
-var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1beta1", Kind: "NodeMetrics"}
+var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "NodeMetrics"}
 
 // Get takes name of the nodeMetrics, and returns the corresponding nodeMetrics object, and an error if there is any.
 func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1beta1.NodeMetrics, err error) {

--- a/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
@@ -33,9 +33,9 @@ type FakePodMetricses struct {
 	ns   string
 }
 
-var podmetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1beta1", Resource: "pods"}
+var podmetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}
 
-var podmetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1beta1", Kind: "PodMetrics"}
+var podmetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "PodMetrics"}
 
 // Get takes name of the podMetrics, and returns the corresponding podMetrics object, and an error if there is any.
 func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1beta1.PodMetrics, err error) {

--- a/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -31,7 +31,7 @@ type MetricsV1beta1Interface interface {
 	PodMetricsesGetter
 }
 
-// MetricsV1beta1Client is used to interact with features provided by the metrics group.
+// MetricsV1beta1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1beta1Client struct {
 	restClient rest.Interface
 }


### PR DESCRIPTION
The generated fake clientsets were using the API group "metrics" instead
of "metrics.k8s.io". The `+groupName` annotation needed to be copied to
these packages to fix it.

As a result, tests using this fake clientset work as expected.

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
